### PR TITLE
Chore: remove any casts in GamePage and prep for logging trim

### DIFF
--- a/src/pages/GamePage.vue
+++ b/src/pages/GamePage.vue
@@ -107,6 +107,15 @@
 import { ref, onMounted } from 'vue'
 import { useQuasar } from 'quasar'
 import GameCanvas from '../components/GameCanvas.vue'
+// Type for methods exposed by GameCanvas via defineExpose
+type GameCanvasExposed = {
+  pauseGame: () => void
+  resumeGame: () => void
+  resetGame: () => void
+  getGameEngine: () => unknown | null
+  loadCritterById: (id: string) => void
+  getCritterInfo: () => { id: number; name: string; species: string; happiness: number; energy: number } | null
+}
 import CritterSelection from '../components/CritterSelection.vue'
 import GameSettings from '../components/GameSettings.vue'
 
@@ -126,7 +135,7 @@ const currentLevel = ref(1)
 const currentScore = ref(0)
 
 // Game canvas reference
-const gameCanvas = ref<InstanceType<typeof GameCanvas> | null>(null)
+const gameCanvas = ref<GameCanvasExposed | null>(null)
 
 // Initialize game on mount
 onMounted(() => {


### PR DESCRIPTION
- Types GameCanvas component ref to exposed interface
- Removes any casts flagged by ESLint (no-explicit-any)

Follow-up: trim superfluous runtime logs in engine systems (animation/movement spam) and change asset monitor to status-change only (partially done).